### PR TITLE
Update to Kotlin 1.2.21

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,7 @@
-kotlin_version = 1.1.50
+kotlin_version = 1.2.0
 
-junitPlatformVersion = 1.0.0
-junitJupiterVersion = 5.0.0
-junitVintageVersion = 4.12.0
+junitPlatformVersion = 1.0.2
+junitJupiterVersion = 5.0.2
 
 mockitoVersion = 2.8.9
 mockitoKotlinVersion = 1.5.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-kotlin_version = 1.2.0
+kotlin_version = 1.2.21
 
 junitPlatformVersion = 1.0.2
 junitJupiterVersion = 5.0.2

--- a/livingdoc-converters/build.gradle
+++ b/livingdoc-converters/build.gradle
@@ -34,7 +34,6 @@ dependencies {
 
     testRuntime("org.junit.platform:junit-platform-launcher:${junitPlatformVersion}")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}")
-    testRuntime("org.junit.vintage:junit-vintage-engine:${junitVintageVersion}")
 }
 
 task javadocJar(type: Jar) {

--- a/livingdoc-converters/src/main/kotlin/org/livingdoc/converters/collection/AbstractCollectionConverter.kt
+++ b/livingdoc-converters/src/main/kotlin/org/livingdoc/converters/collection/AbstractCollectionConverter.kt
@@ -18,7 +18,7 @@ abstract class AbstractCollectionConverter<T : Collection<Any>> : TypeConverter<
     }
 
     private fun tokenize(value: String): List<String> {
-        return value.split(delimiters = defaultSeparator).map { it.trim() }
+        return value.split(delimiters = *arrayOf(defaultSeparator)).map { it.trim() }
     }
 
     private fun convertToTypedParameters(element: AnnotatedElement, documentClass: Class<*>?, tokenized: List<String>): List<Any> {

--- a/livingdoc-engine/build.gradle
+++ b/livingdoc-engine/build.gradle
@@ -36,7 +36,6 @@ dependencies {
 
     testRuntime("org.junit.platform:junit-platform-launcher:${junitPlatformVersion}")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}")
-    testRuntime("org.junit.vintage:junit-vintage-engine:${junitVintageVersion}")
 }
 
 compileTestJava {

--- a/livingdoc-repositories/build.gradle
+++ b/livingdoc-repositories/build.gradle
@@ -33,7 +33,6 @@ dependencies {
 
     testRuntime("org.junit.platform:junit-platform-launcher:${junitPlatformVersion}")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}")
-    testRuntime("org.junit.vintage:junit-vintage-engine:${junitVintageVersion}")
 }
 
 task javadocJar(type: Jar) {

--- a/livingdoc-repositories/src/main/kotlin/org/livingdoc/repositories/config/Configuration.kt
+++ b/livingdoc-repositories/src/main/kotlin/org/livingdoc/repositories/config/Configuration.kt
@@ -13,7 +13,7 @@ data class Configuration(
          * Loads a [Configuration] instance from the `livingdoc.yml` file on the classpath root.
          */
         fun load(): Configuration {
-            val configFile = javaClass.classLoader.getResource("livingdoc.yml")
+            val configFile = Configuration::class.java.classLoader.getResource("livingdoc.yml")
                     ?: throw FileNotFoundException("File not found: livingdoc.yml")
             val inputStream = configFile.openStream()
             return loadFromStream(inputStream)

--- a/livingdoc-repository-file/build.gradle
+++ b/livingdoc-repository-file/build.gradle
@@ -33,7 +33,6 @@ dependencies {
 
     testRuntime("org.junit.platform:junit-platform-launcher:${junitPlatformVersion}")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}")
-    testRuntime("org.junit.vintage:junit-vintage-engine:${junitVintageVersion}")
 }
 
 task javadocJar(type: Jar) {


### PR DESCRIPTION
Update for Kotlin Runtimes and junit5 dependencies
Fixed compile errors and warnings from upgrade
Removed now unnecessary junit vintage dependency